### PR TITLE
Update test_documentation_plugin.py

### DIFF
--- a/src/screwdrivercd/validation/validate_style.py
+++ b/src/screwdrivercd/validation/validate_style.py
@@ -39,8 +39,11 @@ def validate_with_codestyle(report_dir):
 
     pycodestyle_command = os.path.join(bin_dir, 'pycodestyle')
     if not os.path.exists(pycodestyle_command):
-        bin_dir = os.path.dirname(parent_interpreter)
+        bin_dir = os.path.dirname(sys.executable)
         pycodestyle_command = os.path.join(bin_dir, 'pycodestyle')
+        if not os.path.exists(pycodestyle_command):
+            bin_dir = os.path.dirname(parent_interpreter)
+            pycodestyle_command = os.path.join(bin_dir, 'pycodestyle')
 
     package_name = PackageMetadata().metadata['name']
 

--- a/tests/test_documentation_plugin.py
+++ b/tests/test_documentation_plugin.py
@@ -74,7 +74,7 @@ class DocumentationPluginTestCase(unittest.TestCase):
             self._create_test_repo_contents()
             p = self.plugin_class()
             p.build_documentation()
-            self.assertTrue(os.path.exists(f'logs/documentation/{p.name}/{p.name}.build.log'))
+            self.assertTrue(os.path.exists(f'{p.log_dir}/{p.name}.build.log'))
 
 
 class SphinxDocumentationPluginTestCase(DocumentationPluginTestCase):


### PR DESCRIPTION
Fix the test to work when run as a functional test run from the installed package.

This is needed because it is seeing the SD_ARTIFACTS_DIR and writing the documentation to the other location.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

