### PR TITLE
Fix changelog git 18

### DIFF
--- a/changelog.d/60.bugfix.md
+++ b/changelog.d/60.bugfix.md
@@ -1,0 +1,1 @@
+Fix the changelog generator to be able to get the release tags when git version 1.8.x is installed


### PR DESCRIPTION
Fix for issue #60 

Change the git_tag_dates function to use a git command that works on git version 1.8.x and 2.x

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

