### PR TITLE
Update contextmanagers.py

### DIFF
--- a/src/screwdrivercd/utility/contextmanagers.py
+++ b/src/screwdrivercd/utility/contextmanagers.py
@@ -91,7 +91,8 @@ class Timeout(ContextDecorator):
                 signal.alarm(self.timeout.seconds)
             else:
                 self._old_handler = signal.signal(signal.SIGALRM, self._timeout_handler)
-                signal.setitimer(signal.ITIMER_REAL, float(self.timeout.microseconds) / 1000000)
+                seconds = float(self.timeout.total_seconds())
+                signal.setitimer(signal.ITIMER_REAL, seconds)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.timeout:


### PR DESCRIPTION
Timeout decorator does not work if the timeout exceeds 60 seconds.

## Description
Change to using total_seconds() to get the timeout value instead of dividing seconds.  The division does not work for larger values because the larger part of the value overflows to the minutes so a timeout of one minute and 10 seconds would timeout after ten seconds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

