### PR TITLE
Support a config field for adding/updating link to build-triggering commit

### DIFF
--- a/src/screwdrivercd/version/arguments.py
+++ b/src/screwdrivercd/version/arguments.py
@@ -36,6 +36,14 @@ def get_config_default(key, default=None, setup_cfg_filename='setup.cfg'):
     return default
 
 
+def get_bool_equivalent(key) -> bool:
+    """ Get the equivalent bool value for a string key in the config file. """
+
+    if isinstance(key, str) and key.lower() in ['false', '0', 'off']:
+        return False
+    return True
+
+
 def parse_arguments():
     """
     Parse the command line arguments
@@ -47,10 +55,10 @@ def parse_arguments():
     """
     version_type = get_config_default('version_type', default='default')
     update_meta = get_config_default('update_screwdriver_meta', default='false')
-    if isinstance(update_meta, str) and update_meta.lower() in ['false', '0', 'off']:
-        update_meta = False
-    else:
-        update_meta = True
+    update_meta = get_bool_equivalent(update_meta)
+    link_to_commit = get_config_default('link_to_commit', default='false')
+    link_to_commit = get_bool_equivalent(link_to_commit)
+
     version_choices = list(versioners.keys())
     if version_type not in version_choices:
         raise VersionError(f'The version_type in the [screwdrivercd.version] section of setup.cfg has an invalid version type of {version_type!r}')
@@ -60,5 +68,6 @@ def parse_arguments():
     parser.add_argument('--version_type', default=version_type, choices=version_choices, help='Type of version number to generate')
     parser.add_argument('--ignore_meta', default=False, action='store_true', help='Ignore the screwdriver v4 metadata')
     parser.add_argument('--update_meta', default=update_meta, action='store_true', help='Update the screwdriver v4 metadata with the new version')
+    parser.add_argument('--link_to_commit', default=link_to_commit, action='store_true', help='Add/update link to build-triggering commit using its SHA hash')
     result = parser.parse_args()
     return result

--- a/src/screwdrivercd/version/cli.py
+++ b/src/screwdrivercd/version/cli.py
@@ -24,7 +24,7 @@ def main():
     if args.force_update or setupcfg_has_metadata():
         versioner = versioners[args.version_type]
         print(f'Updating version using the {versioner.name} version plugin', flush=True)
-        version = versioner(ignore_meta_version=args.ignore_meta, update_sdv4_meta=args.update_meta)
+        version = versioner(ignore_meta_version=args.ignore_meta, update_sdv4_meta=args.update_meta, link_to_commit=args.link_to_commit)
 
         version.update_setup_cfg_metadata()
         if args.update_meta:

--- a/tests/test_versioners.py
+++ b/tests/test_versioners.py
@@ -13,12 +13,27 @@ from screwdrivercd.version.version_types import versioners, Version, VersionGitR
 class TestVersioners(ScrewdriverTestCase):
     environ_keys = {
         'BASE_PYTHON', 'PACKAGE_DIR', 'PACKAGE_DIRECTORY', 'SD_ARTIFACTS_DIR', 'SD_BUILD', 'SD_BUILD_ID',
-        'SD_PULL_REQUEST',
+        'SD_PULL_REQUEST', 'SCM_URL', 'SD_BUILD_SHA',
     }
 
     def test__version__read_setup_version__no_version(self):
         version = Version(ignore_meta_version=True).read_setup_version()
         self.assertEqual(version, Version.default_version)
+
+    def test__version__get_link_to_commit_using_hash__unset_env_variables(self):
+        version = Version(ignore_meta_version=True, link_to_commit=True).get_link_to_commit_using_hash()
+        self.assertEqual(version.get_link_to_commit_using_hash(), '')
+
+    def test__version__get_link_to_commit_using_hash__set_and_unset_env_variables(self):
+        os.environ['SD_BUILD_SHA'] = 'a5c3785ed8d6a35868bc169f07e40e889087fd2e'
+        version = Version(ignore_meta_version=True, link_to_commit=True).get_link_to_commit_using_hash()
+        self.assertEqual(version.get_link_to_commit_using_hash(), '')
+
+    def test__version__get_link_to_commit_using_hash__set_env_variables(self):
+        os.environ['SCM_URL'] = 'https://github.com'
+        os.environ['SD_BUILD_SHA'] = 'a5c3785ed8d6a35868bc169f07e40e889087fd2e'
+        version = Version(ignore_meta_version=True, link_to_commit=True).get_link_to_commit_using_hash()
+        self.assertEqual(version.get_link_to_commit_using_hash(), 'https://github.com/commit/a5c3785ed8d6a35868bc169f07e40e889087fd2e')
 
     def test__git_revision_count__no_git(self):
         with self.assertRaises(VersionError):


### PR DESCRIPTION
This PR adds support for a configuration field that'll cause the `screwdrivercd_version` utility to add/update the link to the current build's associated commit using said commit's SHA hash in the package's metadata.

## Description
Defined a new field named `link_to_commit` and leveraged existing functions to read the value of the field from the config file. Generated the link to the associated commit using Screwdriver's environment variables, `SCM_URL` and `SD_BUILD_SHA`.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to any related issues here: -->
https://github.com/yahoo/python-screwdrivercd/issues/43

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This adds the link to the associated commit to the metadata for every new package version for improved tracking and visibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been added to `tests/test_versioners.py`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [x] I have added tests to cover my changes.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.