### PR TITLE
Add new version updater: manual_update

### DIFF
--- a/docs/Validation_Helpers.md
+++ b/docs/Validation_Helpers.md
@@ -44,7 +44,7 @@ not use package dependencies with security issues.
 
 This example runs the dependency check
 
-!!! example "screwdriver.yaml - With dependency check
+!!! example "screwdriver.yaml - With dependency check"
 
     ```yaml
     version: 4

--- a/src/screwdrivercd/version/version_types.py
+++ b/src/screwdrivercd/version/version_types.py
@@ -163,6 +163,18 @@ class Version():
         return f'{ver}a{self.pull_request_number}'
 
 
+class VersionManualUpdate(Version):
+    """
+    Version updater that just reads the setup.cfg and takes the `version`
+    number from `metadata` section. Be aware when using this updater, as this
+    updater does not add any unique identifier to the version number.
+
+    It is thus the caller's responsibility to ensure uniqueness is maintained
+    during version update.
+    """
+    name: str = 'manual_update'
+
+
 class VersionUpdateRevision(Version):
     """
     Version updater that updates the revision (last component) of a semetic version.
@@ -288,7 +300,8 @@ versioners = {
     VersionGitRevisionCount.name: VersionGitRevisionCount,
     VersionUTCDate.name: VersionUTCDate,
     VersionSDV4Build.name: VersionSDV4Build,
-    VersionDateSDV4Build.name: VersionDateSDV4Build
+    VersionDateSDV4Build.name: VersionDateSDV4Build,
+    VersionManualUpdate.name: VersionManualUpdate
 }
 
 # Make sure the versioners are listed all lowercase to make identifying them easier

--- a/tests/test_versioners.py
+++ b/tests/test_versioners.py
@@ -5,9 +5,10 @@ import os
 import subprocess  # nosec
 import unittest
 from . import ScrewdriverTestCase
+from tempfile import NamedTemporaryFile
 
 from screwdrivercd.version.exceptions import VersionError
-from screwdrivercd.version.version_types import versioners, Version, VersionGitRevisionCount, VersionSDV4Build, VersionDateSDV4Build, VersionUTCDate
+from screwdrivercd.version.version_types import versioners, Version, VersionGitRevisionCount, VersionSDV4Build, VersionDateSDV4Build, VersionUTCDate, VersionManualUpdate
 
 
 class TestVersioners(ScrewdriverTestCase):
@@ -19,6 +20,15 @@ class TestVersioners(ScrewdriverTestCase):
     def test__version__read_setup_version__no_version(self):
         version = Version(ignore_meta_version=True).read_setup_version()
         self.assertEqual(version, Version.default_version)
+
+    def test__manual_version_update(self):
+        with NamedTemporaryFile('w') as file:
+            setup_cfg_content = '[metadata]\nversion = 1.0.5'
+            file.write(setup_cfg_content)
+
+            file.seek(0)
+            version = VersionManualUpdate(setup_cfg_filename=file.name, ignore_meta_version=True)
+            self.assertEqual(version.generate(), ['1', '0', '5'])
 
     def test__git_revision_count__no_git(self):
         with self.assertRaises(VersionError):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a new version updater that just reads the setup.cfg's metadata section to return a version. The new class `VersionManualUpdate` is a blank extension of `VersionClass`

## Related Issue
NA

## Motivation and Context

The motivation is to add a capability to manually release a package by just reading the version in setup.cfg. This is also good to release a minor version without a patch version increase.

## How Has This Been Tested?
Unittest added

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [x] I have added tests to cover my changes.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
