### PR TITLE
Updaate the minimum version of lxml to address CVE-2022-2309.

### DIFF
--- a/changelog.d/108.bugfix.md
+++ b/changelog.d/108.bugfix.md
@@ -1,0 +1,1 @@
+Require lxml>=4.9.1 to address CVE-2022-2309

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 # Copyright 2019, Verizon Inc.
 # Licensed under the terms of the bsd license.  See the LICENSE file in the project root for terms
 [build-system]
-# Minimum requirements for the build system to execute.
-requires = ["setuptools>40.0.0", "wheel"]  # PEP 508 specifications.
-
+requires = [
+  "setuptools >= 40.9.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ package_dir =
 	=src
 install_requires = 
 	distro
-	lxml
+	lxml>=4.9.1  # CVE-2021-43818 CVE-2022-2309
 	mkdocs
 	mypy
 	parsley
@@ -52,7 +52,7 @@ install_requires =
 	pypirun
 	pyroma
 	requests
-	safety
+	safety<2.0.0
 	setuptools>39.0.0
 	sphinx!=1.8.0
 	termcolor

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ package_dir = src/screwdrivercd
 package_name = screwdrivercd
 
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 skip_missing_interpreters = true
 
 [testenv]
@@ -84,5 +84,5 @@ passenv = SSH_AUTH_SOCK BUILD_NUMBER
 
 [pycodestyle]
 ignore = E1,E2,E3,E4,E5,W293
-max_line_length = 160
+max_line_length = 232
 


### PR DESCRIPTION
Update the lxml dependency to address [CVE-2022-2309](https://yahooinc.whitesourcesoftware.com/Wss/WSS.html#!securityVulnerability;id=CVE-2022-2309;orgToken=b8fdefc5-16c9-4999-a933-015281c0c537)

## Description
Update lxml to require version higher than 4.9.1.

## Motivation and Context
Prevent installing insecure lxml package as a transient dependency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

