### PR TITLE
CVE 2022 2309 2

### DIFF
--- a/changelog.d/108.bugfix.md
+++ b/changelog.d/108.bugfix.md
@@ -1,0 +1,1 @@
+Require lxml>=4.9.1 to address CVE-2022-2309

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 # Copyright 2019, Verizon Inc.
 # Licensed under the terms of the bsd license.  See the LICENSE file in the project root for terms
 [build-system]
-# Minimum requirements for the build system to execute.
-requires = ["setuptools>40.0.0", "wheel"]  # PEP 508 specifications.
-
+requires = [
+  "setuptools >= 40.9.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ package_dir =
 	=src
 install_requires = 
 	distro
-	lxml
+	lxml>=4.9.1  # CVE-2021-43818 CVE-2022-2309
 	mkdocs
 	mypy
 	parsley
@@ -52,7 +52,7 @@ install_requires =
 	pypirun
 	pyroma
 	requests
-	safety
+	safety<2.0.0
 	setuptools>39.0.0
 	sphinx!=1.8.0
 	termcolor

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-author = Verizon Media Python Platform Team
+author = Yahoo Python Platform Team
 author_email = python@yahooinc.com
 classifiers = 
 	Development Status :: 5 - Production/Stable
@@ -10,6 +10,7 @@ classifiers =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 description = Python helper utilities for screwdriver CI/CD
 keywords = ci, cd, screwdriver
 long_description = file:README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ install_requires =
 	pypirun
 	pyroma
 	requests
-	safety<2.0.0
 	setuptools>39.0.0
 	sphinx!=1.8.0
 	termcolor
@@ -86,10 +85,7 @@ screwdrivercd.documentation.plugin =
 	sphinx = screwdrivercd.documentation.sphinx.plugin:SphinxDocumentationPlugin
 
 [options.extras_require]
-documentation = 
-	# dhubbard-sphinx-markdown-tables
-	# markdown<3.2    # This is only needed for the mkdocs-material package to install
-	# pymdown-extensions<6.3  # This is needed to allow markdown < 3.2 to install
+documentation =
 	markdown
 	pymdown-extensions
 	markdown-include
@@ -99,9 +95,6 @@ documentation =
 	pygments
 	recommonmark
 doc_build =
-	# dhubbard-sphinx-markdown-tables
-	# markdown<3.2    # This is only needed for the mkdocs-material package to install
-	# pymdown-extensions<6.3  # This is needed to allow markdown < 3.2 to install
 	markdown
 	pymdown-extensions
 	markdown-include

--- a/src/screwdrivercd/documentation/plugin.py
+++ b/src/screwdrivercd/documentation/plugin.py
@@ -357,7 +357,11 @@ def documentation_plugins(documentation_formats=None):
     entry_points = pkg_resources.iter_entry_points(group='screwdrivercd.documentation.plugin')
 
     for entry_point in entry_points:
-        instance = entry_point.load()()
+        try:
+            instance = entry_point.load()()
+        except pkg_resources.ContextualVersionConflict:
+            logger.warning(f'Documentation plugin {entry_point} failed to load due to a package dependency conflict')
+            raise
         if documentation_formats and instance.name not in documentation_formats:
             continue
         yield instance

--- a/src/screwdrivercd/validation/validate_dependencies.py
+++ b/src/screwdrivercd/validation/validate_dependencies.py
@@ -39,7 +39,7 @@ def validate_with_safety():
 
     # Generate a full text report
     full_report_filename = os.path.join(report_dir, 'safetydb.full')
-    rc = install_and_run(package='safety,.', command=f'safety check --full-report -o "{full_report_filename}"', interpreter=interpreter, upgrade_setuptools=True, upgrade_pip=True)
+    rc = install_and_run(package='safety<2.0.0,.', command=f'safety check --full-report -o "{full_report_filename}"', interpreter=interpreter, upgrade_setuptools=True, upgrade_pip=True)
 
     if rc == 0:
         # update_job_status(status='SUCCESS', message='Dependency check passed')
@@ -48,7 +48,7 @@ def validate_with_safety():
 
     # Generate the report in json format
     json_report_filename = os.path.join(report_dir, 'safetydb.json')
-    rc = install_and_run(package='safety,.', command=f'safety check --json -o "{json_report_filename}"', interpreter=interpreter, upgrade_setuptools=True, upgrade_pip=True)
+    rc = install_and_run(package='safety<2.0.0,.', command=f'safety check --json -o "{json_report_filename}"', interpreter=interpreter, upgrade_setuptools=True, upgrade_pip=True)
 
     bad_packages = -1
     if os.path.exists(json_report_filename):  # pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ package_dir = src/screwdrivercd
 package_name = screwdrivercd
 
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 skip_missing_interpreters = true
 
 [testenv]
@@ -84,5 +84,5 @@ passenv = SSH_AUTH_SOCK BUILD_NUMBER
 
 [pycodestyle]
 ignore = E1,E2,E3,E4,E5,W293
-max_line_length = 160
+max_line_length = 232
 


### PR DESCRIPTION
Update the lxml dependency to address [CVE-2022-2309](https://yahooinc.whitesourcesoftware.com/Wss/WSS.html#!securityVulnerability;id=CVE-2022-2309;orgToken=b8fdefc5-16c9-4999-a933-015281c0c537)

Fix the safety dependency checker wrapper so the build passes,

## Description
Update lxml to require version higher than 4.9.1.

## Motivation and Context
Prevent installing insecure lxml package as a transient dependency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
