### PR TITLE
Update plugin.py

### DIFF
--- a/src/screwdrivercd/documentation/mkdocs/plugin.py
+++ b/src/screwdrivercd/documentation/mkdocs/plugin.py
@@ -17,7 +17,8 @@ class MkDocsDocumentationPlugin(DocumentationPlugin):
     """
     name = 'mkdocs'
     build_output_dir = ''
-    possible_config_files = ['mkdocs.yml', 'docs/mkdocs.yml']
+    # Should cover configuration files supported by https://github.com/mkdocs/mkdocs/blob/3db7b8c9c2473e763fc77525ee17c42e965d3b91/mkdocs/config/base.py#L306
+    possible_config_files = ['mkdocs.yml', 'docs/mkdocs.yml', 'mkdocs.yaml', 'docs/mkdocs.yaml']
 
     def __init__(self, *args, **kwargs):  # pragma: no cover
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Add support for mkdocs.yaml files for parity with mkdocs

See https://github.com/mkdocs/mkdocs/blob/master/mkdocs/config/base.py#L306

## Description
Changes mkdocs plugin to check for `mkdocs.yaml` in addition to `mkdocs.yml`

## Related Issue
Currently using this package with a `mkdocs.yaml` file appears to fail silently.

## Motivation and Context
While the main mkdocs configuration documentation cites `mkdocs.yml` as the canonical filename, `mkdocs.yml` and `mkdocs.yaml` are used interchangeably throughout the mkdocs documentation, so it's reasonable to expect both to work.

## How Has This Been Tested?
Not yet tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

