### PR TITLE
Update setup.cfg

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -25,10 +25,6 @@ jobs:
         template: python/validate_lint
         requires: [~commit, ~pr]
 
-    validate_security:
-        template: python/validate_security
-        requires: [~commit, ~pr]
-
     validate_test:
         template: python/validate_unittest
         steps:
@@ -47,7 +43,7 @@ jobs:
     version:
         template: python/generate_version
         requires: [
-            validate_test, validate_lint, validate_codestyle, validate_security
+            validate_test, validate_lint, validate_codestyle
         ]
 
     publish_test_pypi:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,8 +7,6 @@ shared:
         CHANGELOG_FILENAME: docs/changelog.md
         DOCUMENTATION_DEBUG: True
         DOCUMENTATION_FORMATS: mkdocs
-        # PACKAGE_DIR: src
-        # PACKAGE_DIRECTORY: src
     steps:
         - tag_release: $BASE_PYTHON -m screwdrivercd.repo.release
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -31,13 +31,7 @@ jobs:
                 echo $PACKAGE_VERSION
             - preend: meta set package.version "$PACKAGE_VERSION"
         requires: [~commit, ~pr]
-
-    # The newest version of mypy appears to be broken in a manner that it always flags a specific valid type
-    # annotation.
-    # validate_type:
-    #    template: python/validate_type
-    #     requires: [~commit, ~pr]
-
+        
     version:
         template: python/generate_version
         requires: [

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,10 @@ classifiers =
 	Intended Audience :: Developers
 	License :: OSI Approved :: Apache Software License
 	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 description = Python helper utilities for screwdriver CI/CD
 keywords = ci, cd, screwdriver
 long_description = file:README.md
@@ -22,7 +21,7 @@ project_urls =
 	Change Log = https://yahoo.github.io/python-screwdrivercd/changelog/
 	CI Pipeline = https://cd.screwdriver.cd/pipelines/3063
 url = https://github.com/yahoo/python-screwdrivercd
-version = 0.3.0
+version = 1.3.0
 
 [options]
 namespace_packages = 
@@ -59,7 +58,7 @@ install_requires =
 	toml
 	twine
 	wheel
-python_requires = >="3.6"
+python_requires = >=3.8
 zip_safe = True
 
 [options.entry_points]

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -41,6 +41,7 @@ class TestYum(unittest.TestCase):
         os.chdir(self.tempdir.name)
         with open(CONFIG_FILE, 'w') as config_handle:
             config_handle.write(TEST_CONFIG)
+        print(f'Using configuration: \n{TEST_CONFIG}')
 
     def tearDown(self):
         super().tearDown()

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -19,10 +19,9 @@ requires = ["setuptools", "wheel"]  # PEP 508 specifications.
     install = ['apk', 'apt-get', 'yinst', 'yum', 'pip3']
 
     [tool.sdv4_installdeps.yum]
-        repos.verizon_python_rpms = "https://edge.artifactory.yahoo.com:4443/artifactory/python_rpms/python_rpms.repo"
         deps = [
-            'yahoo_python36;distro_version=="{distro.version()}"',
-            'yahoo_python37;distro_version>="7.5"',
+            'python36;distro_version=="{distro.version()}"',
+            'python37;distro_version>="7.5"',
             'mysql;distro_version<"7"',
             'mariadb;distro_version>="7"'
         ]

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -54,4 +54,4 @@ class TestYum(unittest.TestCase):
     def test__install__default(self):
         installer = YumInstaller(dry_run=True)
         result = installer.install_dependencies()
-        self.assertIn('yahoo_python36', result)
+        self.assertIn('python36', result)

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -51,6 +51,7 @@ class TestYum(unittest.TestCase):
         self.tempdir.cleanup()
 
     @unittest.skipUnless(os.path.exists('/bin/yum'), 'No yum binary present on system')
+    @unittest.skipIf('.' not in distro.version(), 'Distro version does not have a minor number')
     def test__install__default(self):
         installer = YumInstaller(dry_run=True)
         result = installer.install_dependencies()

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -21,10 +21,10 @@ requires = ["setuptools", "wheel"]  # PEP 508 specifications.
     [tool.sdv4_installdeps.yum]
         repos.verizon_python_rpms = "https://edge.artifactory.yahoo.com:4443/artifactory/python_rpms/python_rpms.repo"
         deps = [
-            'yahoo_python36;distro_version=={distro.version()}',
-            'yahoo_python37;distro_version>=7.5',
-            'mysql;distro_version<7',
-            'mariadb;distro_version>=7'
+            'yahoo_python36;distro_version=="{distro.version()}"',
+            'yahoo_python37;distro_version>="7.5"',
+            'mysql;distro_version<"7"',
+            'mariadb;distro_version>="7"'
         ]
 
 '''

--- a/tests/test_installdeps_installer_yum.py
+++ b/tests/test_installdeps_installer_yum.py
@@ -21,10 +21,10 @@ requires = ["setuptools", "wheel"]  # PEP 508 specifications.
     [tool.sdv4_installdeps.yum]
         repos.verizon_python_rpms = "https://edge.artifactory.yahoo.com:4443/artifactory/python_rpms/python_rpms.repo"
         deps = [
-            'yahoo_python36;distro_version=="{distro.version()}"',
-            'yahoo_python37;distro_version>="7.5"',
-            'mysql;distro_version<"7"',
-            'mariadb;distro_version>="7"'
+            'yahoo_python36;distro_version=={distro.version()}',
+            'yahoo_python37;distro_version>=7.5',
+            'mysql;distro_version<7',
+            'mariadb;distro_version>=7'
         ]
 
 '''

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ package_dir = src/screwdrivercd
 package_name = screwdrivercd
 
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 skip_missing_interpreters = true
 
 [testenv]
@@ -15,7 +15,7 @@ deps =
 	six
 	pytest
 	pytest-cov
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = SSH_AUTH_SOCK.BUILD_NUMBER
 extras = 
 	test
 
@@ -45,7 +45,7 @@ deps =
 	pylint
 basepython = python3.6
 commands = {envpython} {envbindir}/pylint --output-format=parseable {[config]package_dir}
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = SSH_AUTH_SOCK,BUILD_NUMBER
 extras = 
 	pylint
 
@@ -55,7 +55,7 @@ deps =
 	lxml
 commands = 
 	mypy --ignore-missing-imports --txt-report artifacts/mypy src/screwdrivercd
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = SSH_AUTH_SOCK,BUILD_NUMBER
 extras = 
 	mypy
 
@@ -67,7 +67,7 @@ deps =
 	recommonmark
 	sphinx_markdown_tables
 commands = {envpython} -m screwdrivercd.documentation
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = SSH_AUTH_SOCK,BUILD_NUMBER
 setenv =
 	DOCUMENTATION_PUBLISH = False
 extras =
@@ -80,7 +80,7 @@ commands =
 	{envpython} {envbindir}/sphinx-apidoc -T -e -M -o doc/source/ src "artifacts/*" "dist/*" "screwdriver/*" "scripts/*" setup.py "tests/*"
 extras = 
 	doc_build
-passenv = SSH_AUTH_SOCK BUILD_NUMBER
+passenv = SSH_AUTH_SOCK,BUILD_NUMBER
 
 [pycodestyle]
 ignore = E1,E2,E3,E4,E5,W293


### PR DESCRIPTION
Update the setup.cfg to require a non-EOL python release (Python 3.8+), also removes the quote marks from the python_requires that now causes an error when building/installing the package.

## Motivation and Context

This change fixes the build with newer versions of setuptools that now generate an exception if the python_requires has quote marks in it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## License

I confirm that this contribution is made under a Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

